### PR TITLE
fix: 让 macOS 平台真正可运行（keystore 跨平台 + 策略平台分派）

### DIFF
--- a/siwx/keystore.py
+++ b/siwx/keystore.py
@@ -1,73 +1,84 @@
-"""密钥库：以 salt 为索引（数据库的真实身份），DPAPI 加密落盘。
+"""密钥库：以 salt 为索引（数据库的真实身份），静止时加密落盘。
 
-修复原项目"按路径存 key + 明文 JSON"的模型缺陷：
-- 同 salt 的多分片共享密钥，salt 才是密钥的真实身份；
-- 静止状态加密（CryptProtectData + 项目熵），不落明文。
+Windows 使用 DPAPI（CryptProtectData + 项目熵）；非 Windows（macOS/Linux）
+作为开关兜底降级为明文 JSON——见 MACOS_SUPPORT.md 的差异说明。接口一致：
+load / save / insert / unique_keys / store_path。
 """
 import ctypes
 import json
 import os
+import sys
 import tempfile
 import time
 from pathlib import Path
 
 _ENTROPY = b"stories-in-wx::keystore::v1"
 
-_crypt32 = ctypes.windll.crypt32
-_kernel32 = ctypes.windll.kernel32
+_USE_DPAPI = sys.platform == "win32"
 
+if _USE_DPAPI:
+    _crypt32 = ctypes.windll.crypt32
+    _kernel32 = ctypes.windll.kernel32
 
-class _DATA_BLOB(ctypes.Structure):
-    _fields_ = [("cbData", ctypes.c_uint), ("pbData", ctypes.c_void_p)]
+    class _DATA_BLOB(ctypes.Structure):
+        _fields_ = [("cbData", ctypes.c_uint), ("pbData", ctypes.c_void_p)]
 
+    _crypt32.CryptProtectData.argtypes = [
+        ctypes.POINTER(_DATA_BLOB), ctypes.c_wchar_p, ctypes.POINTER(_DATA_BLOB),
+        ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint, ctypes.POINTER(_DATA_BLOB),
+    ]
+    _crypt32.CryptProtectData.restype = ctypes.c_int
+    _crypt32.CryptUnprotectData.argtypes = [
+        ctypes.POINTER(_DATA_BLOB), ctypes.POINTER(ctypes.c_wchar_p),
+        ctypes.POINTER(_DATA_BLOB), ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint,
+        ctypes.POINTER(_DATA_BLOB),
+    ]
+    _crypt32.CryptUnprotectData.restype = ctypes.c_int
 
-_crypt32.CryptProtectData.argtypes = [
-    ctypes.POINTER(_DATA_BLOB), ctypes.c_wchar_p, ctypes.POINTER(_DATA_BLOB),
-    ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint, ctypes.POINTER(_DATA_BLOB),
-]
-_crypt32.CryptProtectData.restype = ctypes.c_int
-_crypt32.CryptUnprotectData.argtypes = [
-    ctypes.POINTER(_DATA_BLOB), ctypes.POINTER(ctypes.c_wchar_p),
-    ctypes.POINTER(_DATA_BLOB), ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint,
-    ctypes.POINTER(_DATA_BLOB),
-]
-_crypt32.CryptUnprotectData.restype = ctypes.c_int
+    def _protect(data: bytes) -> bytes:
+        buf = ctypes.create_string_buffer(data, len(data))
+        ent = ctypes.create_string_buffer(_ENTROPY, len(_ENTROPY))
+        blob_in = _DATA_BLOB(len(data), ctypes.cast(buf, ctypes.c_void_p))
+        blob_ent = _DATA_BLOB(len(_ENTROPY), ctypes.cast(ent, ctypes.c_void_p))
+        blob_out = _DATA_BLOB()
+        if not _crypt32.CryptProtectData(
+            ctypes.byref(blob_in), None, ctypes.byref(blob_ent), None, None, 0,
+            ctypes.byref(blob_out),
+        ):
+            raise OSError("CryptProtectData 失败")
+        try:
+            return ctypes.string_at(blob_out.pbData, blob_out.cbData)
+        finally:
+            if blob_out.pbData:
+                _kernel32.LocalFree(ctypes.c_void_p(blob_out.pbData))
 
+    def _unprotect(data: bytes) -> bytes:
+        buf = ctypes.create_string_buffer(data, len(data))
+        ent = ctypes.create_string_buffer(_ENTROPY, len(_ENTROPY))
+        blob_in = _DATA_BLOB(len(data), ctypes.cast(buf, ctypes.c_void_p))
+        blob_ent = _DATA_BLOB(len(_ENTROPY), ctypes.cast(ent, ctypes.c_void_p))
+        blob_out = _DATA_BLOB()
+        if not _crypt32.CryptUnprotectData(
+            ctypes.byref(blob_in), None, ctypes.byref(blob_ent), None, None, 0,
+            ctypes.byref(blob_out),
+        ):
+            raise OSError("CryptUnprotectData 失败")
+        try:
+            return ctypes.string_at(blob_out.pbData, blob_out.cbData)
+        finally:
+            if blob_out.pbData:
+                _kernel32.LocalFree(ctypes.c_void_p(blob_out.pbData))
 
-def _protect(data: bytes) -> bytes:
-    buf = ctypes.create_string_buffer(data, len(data))
-    ent = ctypes.create_string_buffer(_ENTROPY, len(_ENTROPY))
-    blob_in = _DATA_BLOB(len(data), ctypes.cast(buf, ctypes.c_void_p))
-    blob_ent = _DATA_BLOB(len(_ENTROPY), ctypes.cast(ent, ctypes.c_void_p))
-    blob_out = _DATA_BLOB()
-    if not _crypt32.CryptProtectData(
-        ctypes.byref(blob_in), None, ctypes.byref(blob_ent), None, None, 0,
-        ctypes.byref(blob_out),
-    ):
-        raise OSError("CryptProtectData 失败")
-    try:
-        return ctypes.string_at(blob_out.pbData, blob_out.cbData)
-    finally:
-        if blob_out.pbData:
-            _kernel32.LocalFree(ctypes.c_void_p(blob_out.pbData))
+else:
+    _crypt32 = _kernel32 = None
+    _DATA_BLOB = None
 
+    def _protect(data: bytes) -> bytes:
+        # 非 Windows（macOS/Linux）：明文 JSON 兜底（见 MACOS_SUPPORT.md）
+        return data
 
-def _unprotect(data: bytes) -> bytes:
-    buf = ctypes.create_string_buffer(data, len(data))
-    ent = ctypes.create_string_buffer(_ENTROPY, len(_ENTROPY))
-    blob_in = _DATA_BLOB(len(data), ctypes.cast(buf, ctypes.c_void_p))
-    blob_ent = _DATA_BLOB(len(_ENTROPY), ctypes.cast(ent, ctypes.c_void_p))
-    blob_out = _DATA_BLOB()
-    if not _crypt32.CryptUnprotectData(
-        ctypes.byref(blob_in), None, ctypes.byref(blob_ent), None, None, 0,
-        ctypes.byref(blob_out),
-    ):
-        raise OSError("CryptUnprotectData 失败")
-    try:
-        return ctypes.string_at(blob_out.pbData, blob_out.cbData)
-    finally:
-        if blob_out.pbData:
-            _kernel32.LocalFree(ctypes.c_void_p(blob_out.pbData))
+    def _unprotect(data: bytes) -> bytes:
+        return data
 
 
 def store_path() -> Path:

--- a/siwx/strategies/__init__.py
+++ b/siwx/strategies/__init__.py
@@ -7,29 +7,22 @@
 """
 import platform
 
-from siwx.strategies import config_cipher, keystore_source, mmkv, memscan
-
-# 顺序即优先级：密钥库秒回 → MMKV 离线 → Config.Cipher 主力 → 内存字面量兜底
-STRATEGY_REGISTRY_WIN = [keystore_source, mmkv, config_cipher, memscan]
-
-# macOS 专用策略（LLDB + PBKDF2）
-if platform.system() == "Darwin":
-    try:
-        from siwx.strategies import macos_lldb
-        STRATEGY_REGISTRY = STRATEGY_REGISTRY_WIN + [macos_lldb]
-    except ImportError:
-        STRATEGY_REGISTRY = STRATEGY_REGISTRY_WIN
+if platform.system() == "Windows":
+    # Windows: 密钥库 → MMKV 离线 → Config.Cipher 主力 → 内存字面量兜底
+    from siwx.strategies import config_cipher, keystore_source, mmkv, memscan
+    STRATEGY_REGISTRY = [keystore_source, mmkv, config_cipher, memscan]
+    # 依赖微信进程内存扫描的策略（use_memory=False 时跳过）
+    _PROCESS_DEPENDENT = {config_cipher, memscan}
 else:
-    STRATEGY_REGISTRY = STRATEGY_REGISTRY_WIN
-
-# 依赖微信进程的策略（use_memory=False 时跳过）
-_PROCESS_DEPENDENT = {config_cipher, memscan}
-if platform.system() == "Darwin":
-    try:
-        from siwx.strategies import macos_lldb as _macos_lldb_mod
-        _PROCESS_DEPENDENT.add(_macos_lldb_mod)
-    except ImportError:
-        pass
+    # 非 Windows（macOS/Linux）：不加载依赖 winproc(ctypes.windll) 的 Windows 策略，
+    # 否则 import 包即崩溃。macOS 额外启用 LLDB 策略。
+    from siwx.strategies import keystore_source, mmkv
+    STRATEGY_REGISTRY = [keystore_source, mmkv]
+    _PROCESS_DEPENDENT = set()
+    if platform.system() == "Darwin":
+        from siwx.strategies import macos_lldb
+        STRATEGY_REGISTRY.append(macos_lldb)
+        _PROCESS_DEPENDENT.add(macos_lldb)
 
 
 def run_strategies(ctx):


### PR DESCRIPTION
## 背景

上一版 PR #1（已并入 v0.3.1）为项目添加了 macOS LLDB 策略，但其运行时存在两处硬性阻断，导致 **macOS 上项目无法启动、macos_lldb 实际注册不上**：

1. **`siwx/strategies/__init__.py`** 无条件 `from siwx.strategies import config_cipher, keystore_source, mmkv, memscan`。
   `config_cipher` / `memscan` 会 `from siwx import winproc`，而 `winproc.py` 模块级访问 `ctypes.windll.kernel32`（Windows 专属）——在 macOS/Linux 上 `import siwx.strategies` 即抛 `AttributeError`。

2. **`siwx/keystore.py`** 模块级 `_crypt32 = ctypes.windll.crypt32` / `_kernel32`（DPAPI），非 Windows 平台同样 `import` 即崩。而 v0.3.1 的 macOS 文档已声明"用 JSON 文件替代 DPAPI"，代码里却并未实现。

## 改动

- **`siwx/strategies/__init__.py`**：按平台分派注册策略。
  - Windows：保持原有 `[keystore_source, mmkv, config_cipher, memscan]`。
  - macOS/Linux：不再加载依赖 `winproc` 的 Windows 策略，macOS 额外追加 `macos_lldb`（也纳入进程依赖集合）。

- **`siwx/keystore.py`**：DPAPI 逻辑包进 `sys.platform == "win32"` 分支；非 Windows 降级为明文 JSON 兜底。对外接口 `load/save/insert/unique_keys/store_path` 不变。

## 验证

在 Linux 上模拟 macOS（`platform.system()="Darwin"`）全链路验证通过：
- 平台分派后 `STRATEGY_REGISTRY = [keystore_source, mmkv, macos_lldb]`
- 不再 `import winproc` / `config_cipher` / `memscan`
- `extract` / `cli` 导入不再崩溃
- `macos_lldb.extract` Darwin 分支：捕获 passphrase → PBKDF2 派生 → verify → 写入 key_map 且 attrib=`macos_lldb`
- `keystore` JSON 兜底落盘往返 + 小写归一化
- 5 个改动/相关 `.py` 文件 `py_compile` 均通过；Windows 分支逻辑保持不变

## 说明

macOS 实机端到端（LLDB 附加真实微信进程）仍需在 macOS 上做真机验证；本 PR 解决的是平台上可导入、可注册、可运行的基础问题。